### PR TITLE
修复 iPad 点击 content label 崩溃的问题

### DIFF
--- a/DatabaseDemo/DatabaseDemo/DatabaseManager/DatabaseContentTableViewCell.h
+++ b/DatabaseDemo/DatabaseDemo/DatabaseManager/DatabaseContentTableViewCell.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)loadContents:(NSArray *)contents;
 
-@property (nonatomic, copy) void(^clickLabel)(NSInteger column);
+@property (nonatomic, copy) void(^clickLabel)(UILabel *label, NSInteger column);
 
 @end
 

--- a/DatabaseDemo/DatabaseDemo/DatabaseManager/DatabaseContentTableViewCell.m
+++ b/DatabaseDemo/DatabaseDemo/DatabaseManager/DatabaseContentTableViewCell.m
@@ -69,7 +69,7 @@
 - (void)tapLabelAction:(UITapGestureRecognizer *)gesture {
     UILabel *label = (UILabel *)gesture.view;
     if (self.clickLabel) {
-        self.clickLabel(label.tag - 10000);
+        self.clickLabel(label, label.tag - 10000);
     }
 }
 

--- a/DatabaseDemo/DatabaseDemo/DatabaseManager/DatabaseContentViewController.m
+++ b/DatabaseDemo/DatabaseDemo/DatabaseManager/DatabaseContentViewController.m
@@ -126,7 +126,7 @@
     return 30;
 }
 
-- (void)gridView:(DatabaseGridView *)gridView didClickContentInGridIndex:(GridIndex)gridIndex {
+- (void)gridView:(DatabaseGridView *)gridView didClickContentLabel:(UILabel *)label gridIndex:(GridIndex)gridIndex {
     NSString *content = [self contentsAtRow:gridIndex.row][gridIndex.column];
     UIAlertController *alert = [UIAlertController alertControllerWithTitle:content message:nil preferredStyle:UIAlertControllerStyleActionSheet];
     [alert addAction:[UIAlertAction actionWithTitle:@"copy" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
@@ -140,6 +140,15 @@
         [weakSelf jumpmToModifyViewControllerWithContent:content gridIndex:gridIndex];
     }]];
     [alert addAction:[UIAlertAction actionWithTitle:@"cancel" style:UIAlertActionStyleCancel handler:nil]];
+    if ([[UIDevice currentDevice].model isEqualToString:@"iPad"]) {
+        // fix iPad crash when show alert
+        // https://stackoverflow.com/questions/24224916/presenting-a-uialertcontroller-properly-on-an-ipad-using-ios-8
+        [alert setModalPresentationStyle:UIModalPresentationPopover];
+        UIPopoverPresentationController *popPresenter = [alert
+                                                         popoverPresentationController];
+        popPresenter.sourceView = label;
+        popPresenter.sourceRect = label.bounds;
+    }
     [self presentViewController:alert animated:YES completion:nil];
 }
 

--- a/DatabaseDemo/DatabaseDemo/DatabaseManager/DatabaseGridView.h
+++ b/DatabaseDemo/DatabaseDemo/DatabaseManager/DatabaseGridView.h
@@ -17,7 +17,7 @@ typedef struct _GridIndex {
 @protocol DatabaseGridViewDelegate <NSObject>
 
 @optional
-- (void)gridView:(DatabaseGridView *)gridView didClickContentInGridIndex:(GridIndex)gridIndex;
+- (void)gridView:(DatabaseGridView *)gridView didClickContentLabel:(UILabel *)label gridIndex:(GridIndex)gridIndex;
 - (void)gridView:(DatabaseGridView *)gridView didSelectedRow:(NSInteger)row;
 - (void)gridView:(DatabaseGridView *)gridView didDeselectedRow:(NSInteger)row;
 

--- a/DatabaseDemo/DatabaseDemo/DatabaseManager/DatabaseGridView.m
+++ b/DatabaseDemo/DatabaseDemo/DatabaseManager/DatabaseGridView.m
@@ -170,11 +170,11 @@ static CGFloat kGridContentCellHeight = 30.f;
             [cell loadContents:[self.dataSource contentsAtRow:indexPath.row]];
         }
         __weak typeof(self) weakSelf = self;
-        cell.clickLabel = ^(NSInteger column) {
+        cell.clickLabel = ^(UILabel *label, NSInteger column) {
             GridIndex index;
             index.column = column;
             index.row = indexPath.row;
-            [weakSelf didClickContentLabelWithGridIndex:index];
+            [weakSelf didClickContentLabel:label gridIndex:index];
         };
         if (isUnEvenRow) {
             cell.backgroundColor = [UIColor colorWithRed:240/255.0 green:240/255.0 blue:240/255.0 alpha:1];
@@ -218,9 +218,9 @@ static CGFloat kGridContentCellHeight = 30.f;
     }
 }
 
-- (void)didClickContentLabelWithGridIndex:(GridIndex)gridIndex {
-    if (self.delegate && [self.delegate respondsToSelector:@selector(gridView:didClickContentInGridIndex:)]) {
-        [self.delegate gridView:self didClickContentInGridIndex:gridIndex];
+- (void)didClickContentLabel:(UILabel *)label gridIndex:(GridIndex)gridIndex {
+    if (self.delegate && [self.delegate respondsToSelector:@selector(gridView:didClickContentLabel:gridIndex:)]) {
+        [self.delegate gridView:self didClickContentLabel:label gridIndex:gridIndex];
     }
 }
 


### PR DESCRIPTION
iPad 点击 table 列表的时候会崩溃，主要是由于弹窗的问题，崩溃信息如下：

> 2019-01-10 10:28:08.326140+0800 DatabaseDemo[3083:44754] *** Terminating app due to uncaught exception 'NSGenericException', reason: 'Your application has presented a UIAlertController (<UIAlertController: 0x7f810b822200>) of style UIAlertControllerStyleActionSheet from UINavigationController (<UINavigationController: 0x7f810d022200>). The modalPresentationStyle of a UIAlertController with this style is UIModalPresentationPopover. You must provide location information for this popover through the alert controller's popoverPresentationController. You must provide either a sourceView and sourceRect or a barButtonItem.  If this information is not known when you present the alert controller, you may provide it in the UIPopoverPresentationControllerDelegate method -prepareForPopoverPresentation.'
